### PR TITLE
changes post-merge

### DIFF
--- a/FakePCIID/FakePCIID.cpp
+++ b/FakePCIID/FakePCIID.cpp
@@ -60,8 +60,7 @@ bool FakePCIID::hookProvider(IOService *provider)
                         provider->setProperty(key1, value);
                 }
             }
-            
-            OSSafeRelease(iter);
+            iter->release();
         }
     }
 

--- a/FakePCIID/FakePCIID.cpp
+++ b/FakePCIID/FakePCIID.cpp
@@ -51,12 +51,13 @@ bool FakePCIID::hookProvider(IOService *provider)
     {
         if (OSCollectionIterator* iter = OSCollectionIterator::withCollection(providerDict))
         {
-            while (OSSymbol* key = OSDynamicCast(OSSymbol, iter->getNextObject()))
+            while (OSObject* key = iter->getNextObject())
             {
-                if (!provider->getProperty(key))
+                OSSymbol* key1 = OSDynamicCast(OSSymbol, key);
+                if (key1 && !provider->getProperty(key1))
                 {
-                    if (OSObject* value = providerDict->getObject(key))
-                        provider->setProperty(key, value);
+                    if (OSObject* value = providerDict->getObject(key1))
+                        provider->setProperty(key1, value);
                 }
             }
             


### PR DESCRIPTION
I coded it the way I did intentionally.  In the case of an entry that cannot be cast to OSSymbol (original code OSString), I want to continue processing the other entries that follow, not terminate the loop before all of them are examined.

Also, iter is known to be non-NULL so OSSafeRelease is not necessary.
