### PR TITLE
Added all supported Broadcom WiFi cards

### DIFF
--- a/injectors/BCM94352Z_as_BCM94360CS2.plist
+++ b/injectors/BCM94352Z_as_BCM94360CS2.plist
@@ -26,8 +26,12 @@
 			<string>AirPort_Brcm4360</string>
 			<key>IOMatchCategory</key>
 			<string>IODefaultMatchCategory</string>
-			<key>IOPCIPrimaryMatch</key>
-			<string>0x43b114e4</string>
+			<key>IONameMatch</key>
+			<array>
+				<string>pci14e4,4353</string>
+				<string>pci14e4,4357</string>
+				<string>pci14e4,43b1</string>
+			</array>
 			<key>IOProbeScore</key>
 			<integer>901</integer>
 			<key>IOProviderClass</key>
@@ -35,7 +39,7 @@
 			<key>TruePowerOff</key>
 			<true/>
 		</dict>
-		<key>BCM943224HMS as BCM94360CS2</key>
+		<key>Broadcom FakePCIID WiFi</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>org.rehabman.driver.FakePCIID</string>
@@ -43,36 +47,14 @@
 			<string>FakePCIID</string>
 			<key>IOMatchCategory</key>
 			<string>FakePCIID</string>
-			<key>IOPCIPrimaryMatch</key>
-			<string>0x435314e4</string>
-			<key>IOProviderClass</key>
-			<string>IOPCIDevice</string>
-			<key>RM,Build</key>
-			<string>${CONFIGURATION}-${LOGNAME}</string>
-			<key>RM,Version</key>
-			<string>${PRODUCT_NAME} ${MODULE_VERSION}</string>
-			<key>FakeProperties</key>
-			<dict>
-				<key>RM,device-id</key>
-				<data>oEMAAA==</data>
-				<key>RM,vendor-id</key>
-				<data>5BQAAA==</data>
-				<key>RM,subsystem-id</key>
-				<data>NAEAAA==</data>
-				<key>RM,subsystem-vendor-id</key>
-				<data>axAAAA==</data>
-			</dict>
-		</dict>
-		<key>BCM94352Z as BCM94360CS2</key>
-		<dict>
-			<key>CFBundleIdentifier</key>
-			<string>org.rehabman.driver.FakePCIID</string>
-			<key>IOClass</key>
-			<string>FakePCIID</string>
-			<key>IOMatchCategory</key>
-			<string>FakePCIID</string>
-			<key>IOPCIPrimaryMatch</key>
-			<string>0x43b114e4 0x43a014e4</string>
+			<key>IONameMatch</key>
+			<array>
+				<string>pci14e4,43a0</string>
+				<string>pci14e4,432b</string>
+				<string>pci14e4,4353</string>
+				<string>pci14e4,4357</string>
+				<string>pci14e4,43b1</string>
+			</array>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
 			<key>RM,Build</key>

--- a/makefile
+++ b/makefile
@@ -1,7 +1,8 @@
 # really just some handy scripts...
 
 KEXT=FakePCIID.kext
-KEXT_WIFI=FakePCIID_AR9280_as_AR946x.kext
+#KEXT_WIFI=FakePCIID_AR9280_as_AR946x.kext
+KEXT_WIFI=FakePCIID_BCM94352Z_as_BCM94360CS2.kext
 KEXT_GFX=FakePCIID_HD4600_HD4400.kext
 DIST=RehabMan-FakePCIID
 BUILDDIR=./Build

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ KEXT=FakePCIID.kext
 KEXT_WIFI=FakePCIID_BCM94352Z_as_BCM94360CS2.kext
 KEXT_GFX=FakePCIID_HD4600_HD4400.kext
 DIST=RehabMan-FakePCIID
-BUILDDIR=./Build
+BUILDDIR=./Build/Products
 INSTDIR=/System/Library/Extensions
 
 ifeq ($(findstring 32,$(BITS)),32)


### PR DESCRIPTION
It means you don't have to use other injectors for Broadcom WiFi.  Just FakePCIID.kext and the injector will get Airport Extreme.

The injector could probably use a rename, but I didn't want to do that just yet (might create confusion).
