### PR TITLE
fix for WiFi chips handled by both 4331 and 4360

### DIFF
--- a/FakePCIID.xcodeproj/project.pbxproj
+++ b/FakePCIID.xcodeproj/project.pbxproj
@@ -557,7 +557,7 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = FakePCIID/Info.plist;
-				MODULE_VERSION = 1.1.0;
+				MODULE_VERSION = 1.1.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = kext;
 			};
@@ -567,7 +567,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = FakePCIID/Info.plist;
-				MODULE_VERSION = 1.1.0;
+				MODULE_VERSION = 1.1.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = kext;
 			};

--- a/FakePCIID.xcodeproj/project.pbxproj
+++ b/FakePCIID.xcodeproj/project.pbxproj
@@ -557,7 +557,7 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = FakePCIID/Info.plist;
-				MODULE_VERSION = 1.1.1;
+				MODULE_VERSION = 1.1.2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = kext;
@@ -568,7 +568,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = FakePCIID/Info.plist;
-				MODULE_VERSION = 1.1.1;
+				MODULE_VERSION = 1.1.2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = kext;

--- a/FakePCIID.xcodeproj/project.pbxproj
+++ b/FakePCIID.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		841033301B3F629E00349B75 /* FakePCIID_XHCIMux.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FakePCIID_XHCIMux.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		841033321B3F630B00349B75 /* XHCIMux.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = XHCIMux.plist; path = injectors/XHCIMux.plist; sourceTree = "<group>"; };
 		8431923D1A5890E80022C7A1 /* FakePCIID_AR9280_as_AR946x.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FakePCIID_AR9280_as_AR946x.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		8431924D1A58913C0022C7A1 /* FakePCIID_HD4600_HD4400.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FakePCIID_HD4600_HD4400.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		843192601A5892A40022C7A1 /* HD4600_HD4400.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = HD4600_HD4400.plist; path = injectors/HD4600_HD4400.plist; sourceTree = SOURCE_ROOT; };
@@ -37,6 +39,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8410332A1B3F629E00349B75 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		843192391A5890E80022C7A1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -98,6 +107,7 @@
 				843192601A5892A40022C7A1 /* HD4600_HD4400.plist */,
 				843192621A5892AD0022C7A1 /* AR9280_as_AR946x.plist */,
 				D405EF6E1A59104300547072 /* BCM94352Z_as_BCM94360CS2.plist */,
+				841033321B3F630B00349B75 /* XHCIMux.plist */,
 			);
 			name = Injectors;
 			sourceTree = "<group>";
@@ -123,6 +133,7 @@
 				D423B7971A5C0FD8007F2350 /* FakePCIID_Intel_HDMI_Audio.kext */,
 				D43DC86A1A7FA6E5004B2D06 /* FakePCIID_BCM57XX_as_BCM57765.kext */,
 				D410AA971A8A2BC6007FD343 /* FakePCIID_Intel_GbX.kext */,
+				841033301B3F629E00349B75 /* FakePCIID_XHCIMux.kext */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -150,6 +161,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		8410332B1B3F629E00349B75 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8431923A1A5890E80022C7A1 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -204,6 +222,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		841033281B3F629E00349B75 /* FakePCIID_XHCIMux */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8410332D1B3F629E00349B75 /* Build configuration list for PBXNativeTarget "FakePCIID_XHCIMux" */;
+			buildPhases = (
+				841033291B3F629E00349B75 /* Sources */,
+				8410332A1B3F629E00349B75 /* Frameworks */,
+				8410332B1B3F629E00349B75 /* Headers */,
+				8410332C1B3F629E00349B75 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FakePCIID_XHCIMux;
+			productName = FakePCIID_HD4600_HD4400;
+			productReference = 841033301B3F629E00349B75 /* FakePCIID_XHCIMux.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
 		8431923C1A5890E80022C7A1 /* FakePCIID_AR9280_as_AR946x */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 843192451A5890E80022C7A1 /* Build configuration list for PBXNativeTarget "FakePCIID_AR9280_as_AR946x" */;
@@ -381,11 +417,19 @@
 				D423B7961A5C0FD8007F2350 /* FakePCIID_Intel_HDMI_Audio */,
 				D43DC8691A7FA6E5004B2D06 /* FakePCIID_BCM57XX_as_BCM57765 */,
 				D410AA961A8A2BC6007FD343 /* FakePCIID_Intel_GbX */,
+				841033281B3F629E00349B75 /* FakePCIID_XHCIMux */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		8410332C1B3F629E00349B75 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8431923B1A5890E80022C7A1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -438,6 +482,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		841033291B3F629E00349B75 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		843192381A5890E80022C7A1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -492,6 +543,26 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		8410332E1B3F629E00349B75 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = injectors/XHCIMux.plist;
+				MODULE_NAME = "org.rehabman.injector.FakePCIID-XHCIMux";
+				PRODUCT_NAME = FakePCIID_XHCIMux;
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		8410332F1B3F629E00349B75 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = injectors/XHCIMux.plist;
+				MODULE_NAME = "org.rehabman.injector.FakePCIID-XHCIMux";
+				PRODUCT_NAME = FakePCIID_XHCIMux;
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
 		843192461A5890E80022C7A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -557,7 +628,7 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = FakePCIID/Info.plist;
-				MODULE_VERSION = 1.1.2;
+				MODULE_VERSION = 1.2.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = kext;
@@ -568,7 +639,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = FakePCIID/Info.plist;
-				MODULE_VERSION = 1.1.2;
+				MODULE_VERSION = 1.2.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = kext;
@@ -664,6 +735,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		8410332D1B3F629E00349B75 /* Build configuration list for PBXNativeTarget "FakePCIID_XHCIMux" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8410332E1B3F629E00349B75 /* Debug */,
+				8410332F1B3F629E00349B75 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		843192451A5890E80022C7A1 /* Build configuration list for PBXNativeTarget "FakePCIID_AR9280_as_AR946x" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/FakePCIID.xcodeproj/project.pbxproj
+++ b/FakePCIID.xcodeproj/project.pbxproj
@@ -559,6 +559,7 @@
 				INFOPLIST_FILE = FakePCIID/Info.plist;
 				MODULE_VERSION = 1.1.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = kext;
 			};
 			name = Debug;
@@ -569,6 +570,7 @@
 				INFOPLIST_FILE = FakePCIID/Info.plist;
 				MODULE_VERSION = 1.1.1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx10.6;
 				WRAPPER_EXTENSION = kext;
 			};
 			name = Release;

--- a/FakePCIID.xcodeproj/xcshareddata/xcschemes/FakePCIID.xcscheme
+++ b/FakePCIID.xcodeproj/xcshareddata/xcschemes/FakePCIID.xcscheme
@@ -104,6 +104,20 @@
                ReferencedContainer = "container:FakePCIID.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "841033281B3F629E00349B75"
+               BuildableName = "FakePCIID_XHCIMux.kext"
+               BlueprintName = "FakePCIID_XHCIMux"
+               ReferencedContainer = "container:FakePCIID.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/FakePCIID/FakePCIID.cpp
+++ b/FakePCIID/FakePCIID.cpp
@@ -105,7 +105,7 @@ bool FakePCIID::init(OSDictionary *propTable)
         return false;
     }
 
-    IOLog("FakePCIID version 1.1.0 starting.\n");
+    IOLog("FakePCIID version 1.1.1 starting.\n");
 
     // capture vtable pointer for PCIDeviceStub
     PCIDeviceStub *stub = OSTypeAlloc(PCIDeviceStub);

--- a/FakePCIID/FakePCIID.cpp
+++ b/FakePCIID/FakePCIID.cpp
@@ -195,10 +195,14 @@ bool FakePCIID_XHCIMux::hookProvider(IOService *provider)
 {
     DebugLog("FakePCIID_XHCIMux::hookProvider\n");
 
+    // need to run hookProvider first as it injects properties for startup
+    bool init = !mDeviceVtable;
+    bool result = super::hookProvider(provider);
+
     // write initial value to PR2 early...
-    if (!mDeviceVtable)
+    if (init)
         ((PCIDeviceStub_XHCIMux*)provider)->startup();
 
-    return super::hookProvider(provider);
+    return result;
 }
 

--- a/FakePCIID/FakePCIID.cpp
+++ b/FakePCIID/FakePCIID.cpp
@@ -105,7 +105,7 @@ bool FakePCIID::init(OSDictionary *propTable)
         return false;
     }
 
-    IOLog("FakePCIID version 1.1.2 starting.\n");
+    IOLog("FakePCIID version 1.2.0 starting.\n");
 
     // capture vtable pointer for PCIDeviceStub
     PCIDeviceStub *stub = OSTypeAlloc(PCIDeviceStub);
@@ -170,3 +170,35 @@ void FakePCIID::detach(IOService *provider)
     return super::detach(provider);
 }
 #endif
+
+
+//////////////////////////////////////////////////////////////////////////////
+
+OSDefineMetaClassAndStructors(FakePCIID_XHCIMux, FakePCIID);
+
+bool FakePCIID_XHCIMux::init(OSDictionary *propTable)
+{
+    DebugLog("FakePCIID_XHCIMux::init\n");
+
+    if (!super::init(propTable))
+        return false;
+
+    // capture vtable pointer for PCIDeviceStub_XHCIMux
+    PCIDeviceStub *stub = OSTypeAlloc(PCIDeviceStub_XHCIMux);
+    mStubVtable = getVTable(stub);
+    stub->release();
+
+    return true;
+}
+
+bool FakePCIID_XHCIMux::hookProvider(IOService *provider)
+{
+    DebugLog("FakePCIID_XHCIMux::hookProvider\n");
+
+    // write initial value to PR2 early...
+    if (!mDeviceVtable)
+        ((PCIDeviceStub_XHCIMux*)provider)->startup();
+
+    return super::hookProvider(provider);
+}
+

--- a/FakePCIID/FakePCIID.cpp
+++ b/FakePCIID/FakePCIID.cpp
@@ -105,7 +105,7 @@ bool FakePCIID::init(OSDictionary *propTable)
         return false;
     }
 
-    IOLog("FakePCIID version 1.1.1 starting.\n");
+    IOLog("FakePCIID version 1.1.2 starting.\n");
 
     // capture vtable pointer for PCIDeviceStub
     PCIDeviceStub *stub = OSTypeAlloc(PCIDeviceStub);

--- a/FakePCIID/FakePCIID.h
+++ b/FakePCIID/FakePCIID.h
@@ -34,7 +34,7 @@ protected:
     const void *mStubVtable;
     IOPCIDevice* mProvider;
 
-    bool hookProvider(IOService* provider);
+    virtual bool hookProvider(IOService* provider);
     void unhookProvider();
     void mergeFakeProperties(IOService* provider, const char* name, bool force);
 
@@ -47,6 +47,16 @@ public:
 #ifdef DEBUG
     virtual void detach(IOService *provider);
 #endif
+};
+
+class FakePCIID_XHCIMux : public FakePCIID
+{
+    OSDeclareDefaultStructors(FakePCIID_XHCIMux);
+    typedef FakePCIID super;
+
+public:
+    virtual bool init(OSDictionary *propTable);
+    virtual bool hookProvider(IOService *provider);
 };
 
 #endif

--- a/FakePCIID/PCIDeviceStub.cpp
+++ b/FakePCIID/PCIDeviceStub.cpp
@@ -481,7 +481,8 @@ void PCIDeviceStub_XHCIMux::startup()
     UInt32 mask = getBoolProperty(kPR2HonorPR2M, true) ? super::configRead32(super::space, kXHCI_PCIConfig_PR2M) : chipsetMask;
     UInt32 newData = super::configRead32(super::space, kXHCI_PCIConfig_PR2);
     newData &= ~mask;
-    newData |= getUInt32Property(kPR2Force) & chipsetMask;
+    UInt32 force = getUInt32Property(kPR2Force);
+    newData |= force & chipsetMask;
     AlwaysLog("[%04x:%04x] XHCIMux::startup: newData for PR2: 0x%08x\n", deviceInfo & 0xFFFF, deviceInfo >> 16, newData);
 
     super::configWrite32(super::space, kXHCI_PCIConfig_PR2, newData);

--- a/FakePCIID/PCIDeviceStub.cpp
+++ b/FakePCIID/PCIDeviceStub.cpp
@@ -405,4 +405,108 @@ UInt32 PCIDeviceStub::extendedFindPCICapability( UInt32 capabilityID, IOByteCoun
 
 #endif
 
+//////////////////////////////////////////////////////////////////////////////
 
+hack_OSDefineMetaClassAndStructors(PCIDeviceStub_XHCIMux, PCIDeviceStub);
+
+bool PCIDeviceStub_XHCIMux::getBoolProperty(const char* name, bool defValue)
+{
+    bool result = defValue;
+    OSData* data = OSDynamicCast(OSData, getProperty(name));
+    if (data && data->getLength() == 1)
+        result = *static_cast<const UInt8*>(data->getBytesNoCopy());
+    return result;
+}
+
+UInt32 PCIDeviceStub_XHCIMux::getUInt32Property(const char* name)
+{
+    UInt32 result = 0;
+    OSData* data = OSDynamicCast(OSData, getProperty(name));
+    if (data && data->getLength() == 4)
+        result = *static_cast<const UInt32*>(data->getBytesNoCopy());
+    return result;
+}
+
+void PCIDeviceStub_XHCIMux::configWrite32(IOPCIAddressSpace space, UInt8 offset, UInt32 data)
+{
+    UInt32 deviceInfo = super::configRead32(space, kIOPCIConfigVendorID);
+    DebugLog("[%04x:%04x] XHCIMux::configWrite32 address space(0x%08x, 0x%02x) data: 0x%08x\n",
+             deviceInfo & 0xFFFF, deviceInfo >> 16, space.bits, offset, data);
+
+    UInt32 newData = data;
+    switch (offset)
+    {
+        case kXHCI_PCIConfig_PR2:
+        {
+            if (getBoolProperty(kPR2Block, false))
+            {
+                AlwaysLog("[%04x:%04x] XHCIMux::configWrite32 address space(0x%08x, 0x%02x) data: 0x%08x blocked\n",
+                         deviceInfo & 0xFFFF, deviceInfo >> 16, space.bits, offset, data);
+                return;
+            }
+            UInt32 chipsetMask = getUInt32Property(kPR2ChipsetMask);
+            UInt32 mask = getBoolProperty(kPR2HonorPR2M, true) ? super::configRead32(space, kXHCI_PCIConfig_PR2M) : chipsetMask;
+            newData = super::configRead32(space, kXHCI_PCIConfig_PR2);
+            newData &= ~mask;
+            newData |= getUInt32Property(kPR2Force) & chipsetMask;
+        }
+        break;
+
+        case kXHCI_PCIConfig_PR2M:
+        {
+            if (getBoolProperty(kPR2MBlock, false))
+            {
+                AlwaysLog("[%04x:%04x] XHCIMux::configWrite32 address space(0x%08x, 0x%02x) data: 0x%08x blocked\n",
+                          deviceInfo & 0xFFFF, deviceInfo >> 16, space.bits, offset, data);
+                return;
+            }
+        }
+        break;
+    }
+
+    if (newData != data)
+    {
+        AlwaysLog("[%04x:%04x] XHCIMux::configWrite32 address space(0x%08x, 0x%02x) data: 0x%08x -> 0x%08x\n",
+                 deviceInfo & 0xFFFF, deviceInfo >> 16, space.bits, offset, data, newData);
+    }
+
+    super::configWrite32(space, offset, newData);
+}
+
+void PCIDeviceStub_XHCIMux::startup()
+{
+    UInt32 deviceInfo = super::configRead32(super::space, kIOPCIConfigVendorID);
+
+    UInt32 chipsetMask = getUInt32Property(kPR2ChipsetMask);
+    UInt32 mask = getBoolProperty(kPR2HonorPR2M, true) ? super::configRead32(super::space, kXHCI_PCIConfig_PR2M) : chipsetMask;
+    UInt32 newData = super::configRead32(super::space, kXHCI_PCIConfig_PR2);
+    newData &= ~mask;
+    newData |= getUInt32Property(kPR2Force) & chipsetMask;
+    AlwaysLog("[%04x:%04x] XHCIMux::startup: newData for PR2: 0x%08x\n", deviceInfo & 0xFFFF, deviceInfo >> 16, newData);
+
+    super::configWrite32(super::space, kXHCI_PCIConfig_PR2, newData);
+}
+
+#ifdef HOOK_ALL
+
+void PCIDeviceStub_XHCIMux::configWrite16(IOPCIAddressSpace space, UInt8 offset, UInt16 data)
+{
+    UInt32 deviceInfo = super::configRead32(super::space, kIOPCIConfigVendorID);
+
+    DebugLog("[%04x:%04x] configWrite16 address space(0x%08x, 0x%02x) data: 0x%04x\n",
+             deviceInfo & 0xFFFF, deviceInfo >> 16, space.bits, offset, data);
+
+    super::configWrite16(space, offset, data);
+}
+
+void PCIDeviceStub_XHCIMux::configWrite8(IOPCIAddressSpace space, UInt8 offset, UInt8 data)
+{
+    UInt32 deviceInfo = super::configRead32(super::space, kIOPCIConfigVendorID);
+
+    DebugLog("[%04x:%04x] configWrite8 address space(0x%08x, 0x%02x) data: 0x%02x\n",
+             deviceInfo & 0xFFFF, deviceInfo >> 16, space.bits, offset, data);
+
+    super::configWrite8(space, offset, data);
+}
+
+#endif

--- a/FakePCIID/PCIDeviceStub.h
+++ b/FakePCIID/PCIDeviceStub.h
@@ -71,4 +71,33 @@ public:
 #endif
 };
 
+#define kXHCI_PCIConfig_PR2     0xd0
+#define kXHCI_PCIConfig_PR2M    0xd4
+
+#define kPR2Force       "RM,pr2-force"
+#define kPR2Init        "RM,pr2-init"
+#define kPR2Block       "RM,pr2-block"
+#define kPR2MBlock      "RM,pr2m-block"
+#define kPR2HonorPR2M   "RM,pr2-honor-pr2m"
+#define kPR2ChipsetMask "RM,pr2-chipset-mask"
+
+class PCIDeviceStub_XHCIMux : public PCIDeviceStub
+{
+    OSDeclareDefaultStructors(PCIDeviceStub_XHCIMux);
+    typedef PCIDeviceStub super;
+
+protected:
+    bool getBoolProperty(const char* name, bool defValue);
+    UInt32 getUInt32Property(const char* name);
+
+public:
+    virtual void configWrite32(IOPCIAddressSpace space, UInt8 offset, UInt32 data);
+#ifdef HOOK_ALL
+    virtual void configWrite16(IOPCIAddressSpace space, UInt8 offset, UInt16 data);
+    virtual void configWrite8(IOPCIAddressSpace space, UInt8 offset, UInt8 data);
+#endif
+
+    void startup();
+};
+
 #endif

--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ end;
 
   This particular application of FakePCIID.kext is used to emulate an authentic Apple Airport Extreme (BCM94360CS2), when using a BCM94352Z NGFF M.2 WiFi module.
 
-In order to create your own injector, you should be familiar with IOKit matching and kext Info.plist files.  There is ample documentation available on developer.apple.com.  Use the existing injectors as a template to build your own.
-
-
 - FakePCIID_BCM57XX_as_BCM57765.kext:
    This kext will attach to numerous unsupported BCM57XX Ethernet devices in order to make the native drivers work for a wider variety of BCM Ethernet chipsets that are compatible, but not supported due to probe testing of PCI device-id/subdevice-id values.
    Further details here: http://www.tonymacx86.com/network/155984-fakepciid-broadcom-bcm57xx-network-oob.html
@@ -101,6 +98,9 @@ In order to create your own injector, you should be familiar with IOKit matching
     RM,pr2-chipset-mask: Writes to XUSB2PR are masked by this value.  This is defined by the chipset documentation.  Default value depends on chipset.
 
    Refer to Intel 7/8/9-series chipset data sheet for more info.
+
+
+In order to create your own injector, you should be familiar with IOKit matching and kext Info.plist files.  There is ample documentation available on developer.apple.com.  Use the existing injectors as a template to build your own.
 
 
 ### DSDT patches

--- a/injectors/BCM94352Z_as_BCM94360CS2.plist
+++ b/injectors/BCM94352Z_as_BCM94360CS2.plist
@@ -39,7 +39,7 @@
 			<key>TruePowerOff</key>
 			<true/>
 		</dict>
-		<key>Broadcom FakePCIID WiFi</key>
+		<key>Broadcom FakePCIID WiFi 43a0</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>org.rehabman.driver.FakePCIID</string>
@@ -50,8 +50,6 @@
 			<key>IONameMatch</key>
 			<array>
 				<string>pci14e4,43a0</string>
-				<string>pci14e4,432b</string>
-				<string>pci14e4,4353</string>
 				<string>pci14e4,4357</string>
 				<string>pci14e4,43b1</string>
 			</array>
@@ -67,6 +65,77 @@
 				<data>oEMAAA==</data>
 				<key>RM,vendor-id</key>
 				<data>5BQAAA==</data>
+				<key>RM,subsystem-id</key>
+				<data>NAEAAA==</data>
+				<key>RM,subsystem-vendor-id</key>
+				<data>axAAAA==</data>
+			</dict>
+		</dict>
+		<key>Broadcom FakePCIID WiFi no device-id</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>org.rehabman.driver.FakePCIID</string>
+			<key>IOClass</key>
+			<string>FakePCIID</string>
+			<key>IOMatchCategory</key>
+			<string>FakePCIID</string>
+			<key>IONameMatch</key>
+			<array>
+				<string>pci14e4,4331</string>
+				<string>pci14e4,4353</string>
+				<string>pci14e4,432b</string>
+				<string>pci14e4,43ba</string>
+				<string>pci14e4,43a3</string>
+				<string>pci14e4,43a0</string>
+			</array>
+			<key>IOProviderClass</key>
+			<string>IOPCIDevice</string>
+			<key>RM,Build</key>
+			<string>${CONFIGURATION}-${LOGNAME}</string>
+			<key>RM,Version</key>
+			<string>${PRODUCT_NAME} ${MODULE_VERSION}</string>
+			<key>FakeProperties</key>
+			<dict>
+				<key>RM,vendor-id</key>
+				<data>5BQAAA==</data>
+				<key>RM,subsystem-id</key>
+				<data>NAEAAA==</data>
+				<key>RM,subsystem-vendor-id</key>
+				<data>axAAAA==</data>
+			</dict>
+		</dict>
+		<key>Broadcom FakePCIID WiFi 43224</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>org.rehabman.driver.FakePCIID</string>
+			<key>IOClass</key>
+			<string>FakePCIID</string>
+			<key>IOMatchCategory</key>
+			<string>FakePCIID</string>
+			<key>IONameMatch</key>
+			<array>
+				<string>pci106b,4e</string>
+				<string>pci14e4,4311</string>
+				<string>pci14e4,4312</string>
+				<string>pci14e4,4313</string>
+				<string>pci14e4,4318</string>
+				<string>pci14e4,4319</string>
+				<string>pci14e4,431a</string>
+				<string>pci14e4,4320</string>
+				<string>pci14e4,4324</string>
+				<string>pci14e4,4325</string>
+				<string>pci14e4,4328</string>
+				<string>pci14e4,432c</string>
+				<string>pci14e4,432d</string>
+			</array>
+			<key>IOProviderClass</key>
+			<string>IOPCIDevice</string>
+			<key>RM,Build</key>
+			<string>${CONFIGURATION}-${LOGNAME}</string>
+			<key>RM,Version</key>
+			<string>${PRODUCT_NAME} ${MODULE_VERSION}</string>
+			<key>FakeProperties</key>
+			<dict>
 				<key>RM,subsystem-id</key>
 				<data>NAEAAA==</data>
 				<key>RM,subsystem-vendor-id</key>

--- a/injectors/BCM94352Z_as_BCM94360CS2.plist
+++ b/injectors/BCM94352Z_as_BCM94360CS2.plist
@@ -31,6 +31,7 @@
 				<string>pci14e4,4353</string>
 				<string>pci14e4,4357</string>
 				<string>pci14e4,43b1</string>
+				<string>pci14e4,43b2</string>
 			</array>
 			<key>IOProbeScore</key>
 			<integer>901</integer>

--- a/injectors/XHCIMux.plist
+++ b/injectors/XHCIMux.plist
@@ -49,7 +49,7 @@
 				<key>RM,pr2-honor-pr2m</key>
 				<data>AQ==</data>
 				<key>RM,pr2-chipset-mask</key>
-				<data>8AAAAA==</data>
+				<data>DwAAAA==</data>
 			</dict>
 		</dict>
 		<key>XHCIMux 8 and 9-series</key>

--- a/injectors/XHCIMux.plist
+++ b/injectors/XHCIMux.plist
@@ -63,7 +63,7 @@
 			<key>IOMatchCategory</key>
 			<string>FakePCIID_XHCIMux</string>
 			<key>IOPCIPrimaryMatch</key>
-			<string>0x9c318086 0x8c318086 0x8cb18086</string>
+			<string>0x9c318086 0x9cb18086 0x8c318086 0x8cb18086</string>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
 			<key>RM,Build</key>

--- a/injectors/XHCIMux.plist
+++ b/injectors/XHCIMux.plist
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Source Code</key>
+	<string>https://github.com/RehabMan/FakePCIID</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.rehabman.injector.FakePCIID-XHCIMux</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>FakePCIID_XHCIMux</string>
+	<key>CFBundlePackageType</key>
+	<string>KEXT</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$MODULE_VERSION</string>
+	<key>CFBundleVersion</key>
+	<string>$MODULE_VERSION</string>
+	<key>IOKitPersonalities</key>
+	<dict>
+		<key>XHCIMux 7-series</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>org.rehabman.driver.FakePCIID</string>
+			<key>IOClass</key>
+			<string>FakePCIID_XHCIMux</string>
+			<key>IOProbeScore</key>
+			<integer>9001</integer>
+			<key>IOMatchCategory</key>
+			<string>FakePCIID_XHCIMux</string>
+			<key>IOPCIPrimaryMatch</key>
+			<string>0x1e318086</string>
+			<key>IOProviderClass</key>
+			<string>IOPCIDevice</string>
+			<key>RM,Build</key>
+			<string>${CONFIGURATION}-${LOGNAME}</string>
+			<key>RM,Version</key>
+			<string>${PRODUCT_NAME} ${MODULE_VERSION}</string>
+			<key>FakeProperties</key>
+			<dict>
+				<key>RM,pr2-force</key>
+				<data>AAAAAA==</data>
+				<key>RM,pr2-init</key>
+				<data>AQ==</data>
+				<key>RM,pr2-block</key>
+				<data>AA==</data>
+				<key>RM,pr2m-block</key>
+				<data>AQ==</data>
+				<key>RM,pr2-honor-pr2m</key>
+				<data>AQ==</data>
+				<key>RM,pr2-chipset-mask</key>
+				<data>8AAAAA==</data>
+			</dict>
+		</dict>
+		<key>XHCIMux 8 and 9-series</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>org.rehabman.driver.FakePCIID</string>
+			<key>IOProbeScore</key>
+			<integer>9001</integer>
+			<key>IOClass</key>
+			<string>FakePCIID_XHCIMux</string>
+			<key>IOMatchCategory</key>
+			<string>FakePCIID_XHCIMux</string>
+			<key>IOPCIPrimaryMatch</key>
+			<string>0x9c318086 0x8c318086 0x8cb18086</string>
+			<key>IOProviderClass</key>
+			<string>IOPCIDevice</string>
+			<key>RM,Build</key>
+			<string>${CONFIGURATION}-${LOGNAME}</string>
+			<key>RM,Version</key>
+			<string>${PRODUCT_NAME} ${MODULE_VERSION}</string>
+			<key>FakeProperties</key>
+			<dict>
+				<key>RM,pr2-force</key>
+				<data>AAAAAA==</data>
+				<key>RM,pr2-init</key>
+				<data>AQ==</data>
+				<key>RM,pr2-block</key>
+				<data>AA==</data>
+				<key>RM,pr2m-block</key>
+				<data>AQ==</data>
+				<key>RM,pr2-honor-pr2m</key>
+				<data>AQ==</data>
+				<key>RM,pr2-chipset-mask</key>
+				<data>/z8AAA==</data>
+			</dict>
+		</dict>
+	</dict>
+	<key>OSBundleRequired</key>
+	<string>Root</string>
+</dict>
+</plist>

--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@ KEXT=FakePCIID.kext
 #KEXT_WIFI=FakePCIID_AR9280_as_AR946x.kext
 KEXT_WIFI=FakePCIID_BCM94352Z_as_BCM94360CS2.kext
 KEXT_GFX=FakePCIID_HD4600_HD4400.kext
+KEXT_USB=FakePCIID_XHCIMux.kext
 DIST=RehabMan-FakePCIID
 BUILDDIR=./Build/Products
 INSTDIR=/System/Library/Extensions
@@ -39,8 +40,11 @@ install_debug:
 	sudo cp -R $(BUILDDIR)/Debug/$(KEXT) $(INSTDIR)
 	sudo rm -Rf $(INSTDIR)/$(KEXT_GFX)
 	sudo cp -R $(BUILDDIR)/Debug/$(KEXT_GFX) $(INSTDIR)
-	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT); fi
-	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_GFX); fi
+	sudo rm -Rf $(INSTDIR)/$(KEXT_WIFI)
+	sudo cp -R $(BUILDDIR)/Debug/$(KEXT_WIFI) $(INSTDIR)
+	if [ "`which tag`" != "" ]; then sudo tag -a Purple $(INSTDIR)/$(KEXT); fi
+	if [ "`which tag`" != "" ]; then sudo tag -a Purple $(INSTDIR)/$(KEXT_GFX); fi
+	if [ "`which tag`" != "" ]; then sudo tag -a Purple $(INSTDIR)/$(KEXT_WIFI); fi
 	make update_kernelcache
 
 .PHONY: install
@@ -49,22 +53,25 @@ install:
 	sudo cp -R $(BUILDDIR)/Release/$(KEXT) $(INSTDIR)
 	sudo rm -Rf $(INSTDIR)/$(KEXT_GFX)
 	sudo cp -R $(BUILDDIR)/Release/$(KEXT_GFX) $(INSTDIR)
-	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT); fi
-	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_GFX); fi
-	make update_kernelcache
-
-.PHONY: install_debug_wifi
-install_debug_wifi:
-	sudo rm -Rf $(INSTDIR)/$(KEXT_WIFI)
-	sudo cp -R $(BUILDDIR)/Debug/$(KEXT_WIFI) $(INSTDIR)
-	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_WIFI); fi
-	make install_debug
-
-.PHONY: install_wifi
-install_wifi:
 	sudo rm -Rf $(INSTDIR)/$(KEXT_WIFI)
 	sudo cp -R $(BUILDDIR)/Release/$(KEXT_WIFI) $(INSTDIR)
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT); fi
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_GFX); fi
 	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_WIFI); fi
+	make update_kernelcache
+
+.PHONY: install_debug_usb
+install_debug_usb:
+	sudo rm -Rf $(INSTDIR)/$(KEXT_USB)
+	sudo cp -R $(BUILDDIR)/Debug/$(KEXT_USB) $(INSTDIR)
+	if [ "`which tag`" != "" ]; then sudo tag -a Purple $(INSTDIR)/$(KEXT_USB); fi
+	make install_debug
+
+.PHONY: install_usb
+install_usb:
+	sudo rm -Rf $(INSTDIR)/$(KEXT_USB)
+	sudo cp -R $(BUILDDIR)/Release/$(KEXT_USB) $(INSTDIR)
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_USB); fi
 	make install
 
 .PHONY: distribute

--- a/makefile
+++ b/makefile
@@ -39,6 +39,8 @@ install_debug:
 	sudo cp -R $(BUILDDIR)/Debug/$(KEXT) $(INSTDIR)
 	sudo rm -Rf $(INSTDIR)/$(KEXT_GFX)
 	sudo cp -R $(BUILDDIR)/Debug/$(KEXT_GFX) $(INSTDIR)
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT); fi
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_GFX); fi
 	make update_kernelcache
 
 .PHONY: install
@@ -47,18 +49,22 @@ install:
 	sudo cp -R $(BUILDDIR)/Release/$(KEXT) $(INSTDIR)
 	sudo rm -Rf $(INSTDIR)/$(KEXT_GFX)
 	sudo cp -R $(BUILDDIR)/Release/$(KEXT_GFX) $(INSTDIR)
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT); fi
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_GFX); fi
 	make update_kernelcache
 
 .PHONY: install_debug_wifi
 install_debug_wifi:
 	sudo rm -Rf $(INSTDIR)/$(KEXT_WIFI)
 	sudo cp -R $(BUILDDIR)/Debug/$(KEXT_WIFI) $(INSTDIR)
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_WIFI); fi
 	make install_debug
 
 .PHONY: install_wifi
 install_wifi:
 	sudo rm -Rf $(INSTDIR)/$(KEXT_WIFI)
 	sudo cp -R $(BUILDDIR)/Release/$(KEXT_WIFI) $(INSTDIR)
+	if [ "`which tag`" != "" ]; then sudo tag -a Blue $(INSTDIR)/$(KEXT_WIFI); fi
 	make install
 
 .PHONY: distribute


### PR DESCRIPTION
Some devices appear both in the 4331 kext and the 4360.  Not sure how the two ::probe functions decide which one wins, but these changes to the FakePCIID Info.plist allow those devices meant to use the 4331 kext to still use it (no device-id mapping in that case, just the rebranding to Apple for Airport Extreme).

Also, experimentally adding mappings for the 43224 kext (just for Airport Extreme branding).
